### PR TITLE
Added code fix to reset camera setting if camera screen detached

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -350,6 +350,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
     updateLifecycleState()
+    lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
   }
 
   /**


### PR DESCRIPTION
Added code fix to reset camera setting if camera screen detached  for the ticket: https://trac.parkcitygroup.com/ticket/28829
- Flashlight turns back on when closing out scanner

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
